### PR TITLE
changed id to make non XPI installation smooth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 */locale/*/*.html
 */chrome
 */contrib/vim/*.vba
+downloads
 
 ## Editor backup and swap files
 *~

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DIRS = teledactyl pentadactyl melodactyl
+DIRS = pentadactyl
 TARGETS = clean distclean doc help info jar release xpi
 .SILENT:
 

--- a/common/modules/base.jsm
+++ b/common/modules/base.jsm
@@ -1682,9 +1682,9 @@ function iter(obj, iface) {
     return Iter(res);
 }
 update(iter, {
-    toArray: deprecated("Array.from", function toArray(iter) {
+    toArray: function toArray(iter) {
         return Array.from(iter);
-    }),
+    },
 
     // See Ary.prototype for API docs.
     toObject: function toObject(iter) {
@@ -1954,10 +1954,10 @@ var Ary = Class("Ary", Array, {
      * @param {Array} ary
      * @returns {Iterator(Object)}
      */
-    iterValues: deprecated("Array#values", function* iterValues(ary) {
+    iterValues: function* iterValues(ary) {
         for (let i = 0; i < ary.length; i++)
             yield ary[i];
-    }),
+    },
 
     /**
      * Returns an Iterator for an array's indices and values.

--- a/common/modules/buffer.jsm
+++ b/common/modules/buffer.jsm
@@ -2418,7 +2418,13 @@ var Buffer = Module("Buffer", {
 
                     let elements = Array.from(frames)
                                         .flatMap(win => DOM.XPath(xpath, win.document))
-                                        .filter(elem => {
+                                        .flatMap(elems => {
+                                            var _tmp=[];
+                                            for(var i=0; i<elems.snapshotLength; i++) {
+                                                _tmp.push(elems.snapshotItem(i));
+                                            }
+                                            return _tmp;
+                                        }).filter(elem => {
 
                         if (isinstance(elem, [Ci.nsIDOMHTMLFrameElement,
                                               Ci.nsIDOMHTMLIFrameElement]))
@@ -2426,7 +2432,7 @@ var Buffer = Module("Buffer", {
 
                         elem = DOM(elem);
 
-                        if (elem[0].readOnly || elem[0].disabled || !DOM(elem).isEditable)
+                        if (!elem || !elem.length || elem[0].readOnly || elem[0].disabled || !DOM(elem).isEditable)
                             return false;
 
                         let style = elem.style;

--- a/common/modules/commands.jsm
+++ b/common/modules/commands.jsm
@@ -627,7 +627,7 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
         extra.hive = this;
         extra.parsedSpecs = Command.parseSpecs(specs);
 
-        let names = extra.parsedSpecs.flatMap();
+        let names = extra.parsedSpecs;
         let name = names[0];
 
         if (this.name != "builtin") {

--- a/common/modules/finder.jsm
+++ b/common/modules/finder.jsm
@@ -488,19 +488,19 @@ var RangeFind = Class("RangeFind", {
         else {
             this.selections = [];
             let string = this.lastString;
-            for (let r of this.iter(string)) {
-                let controller = this.range.selectionController;
-                for (let node = r.startContainer; node; node = node.parentNode)
-                    if (node instanceof Ci.nsIDOMNSEditableElement) {
-                        controller = node.editor.selectionController;
-                        break;
-                    }
+            //for (let r of this.iter(string)) {
+            //    let controller = this.range.selectionController;
+            //    for (let node = r.startContainer; node; node = node.parentNode)
+            //        if (node instanceof Ci.nsIDOMNSEditableElement) {
+            //            controller = node.editor.selectionController;
+            //            break;
+            //        }
 
-                let sel = controller.getSelection(Ci.nsISelectionController.SELECTION_FIND);
-                sel.addRange(r);
-                if (this.selections.indexOf(sel) < 0)
-                    this.selections.push(sel);
-            }
+            //    let sel = controller.getSelection(Ci.nsISelectionController.SELECTION_FIND);
+            //    sel.addRange(r);
+            //    if (this.selections.indexOf(sel) < 0)
+            //        this.selections.push(sel);
+            //}
             this.highlighted = this.lastString;
             if (this.lastRange)
                 this.selectedRange = this.lastRange;

--- a/pentadactyl/install.rdf
+++ b/pentadactyl/install.rdf
@@ -2,10 +2,10 @@
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
     <Description about="urn:mozilla:install-manifest"
-        em:id="{ff87f0b6-b523-4308-8de6-8569cfb794ca}"
+        em:id="pentadactyl@addons.palemoon.org"
         em:type="2"
         em:name="Pentadactyl"
-        em:version="1.3.0"
+        em:version="1.3.1"
         em:description="The ultimate Vi-style browsing extension"
         em:homepageURL="https://github.com/pentadactyl/pentadactyl"
         em:bootstrap="true"
@@ -31,10 +31,19 @@
         <em:contributor>Štěpán Němec</em:contributor>
 
         <em:targetApplication>
-            <Description
-                em:id="{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}"
-                em:minVersion="27.0"
-                em:maxVersion="50.*"/>
+            <Description>
+                <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+                <em:minVersion>25.0</em:minVersion>
+                <em:maxVersion>28.*</em:maxVersion>
+            </Description>
+        </em:targetApplication>
+        <em:targetApplication>
+            <Description>
+                <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+                <em:minVersion>52.0</em:minVersion>
+                <em:maxVersion>56.*</em:maxVersion>
+                <em:basilisk>true</em:basilisk>
+            </Description>
         </em:targetApplication>
     </Description>
 </RDF>

--- a/pentadactyl/install.rdf
+++ b/pentadactyl/install.rdf
@@ -2,7 +2,7 @@
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
     <Description about="urn:mozilla:install-manifest"
-        em:id="{ff87f0b6-b523-4308-8de6-8569cfb794ca}"
+        em:id="pentadactyl@addons.palemoon.org"
         em:type="2"
         em:name="Pentadactyl"
         em:version="1.3.0"


### PR DESCRIPTION
Really cool to see this extension staying alive. I tried to make a "non XPI installation" following the instructions in the README.md but it failed. Changing the ID in `install.rdf` to: `pentadactyl@addons.palemoon.org` will make the instructions valid.