### PR TITLE
Introduces option "showhinttext"

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -370,6 +370,9 @@ var HintSession = Class("HintSession", CommandMode, {
                 hint.span.setAttribute("style", ["display: none; left:", leftPos, "px; top:", topPos, "px"].join(""));
                 container.appendChild(hint.span);
 
+                if (!options["showhinttext"]) {
+                    hint.showText = false;
+                }
                 this.pageHints.push(hint);
             }
 
@@ -1358,6 +1361,10 @@ var Hints = Module("hints", {
 
                 validator: DOM.validateMatcher
             });
+
+        options.add(["showhinttext"],
+            "Enables or disables showing hints' related texts",
+            "boolean", true);
 
         options.add(["hinttags", "ht"],
             "XPath or CSS selector strings of hintable elements for Hints mode",

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -954,6 +954,19 @@
 </item>
 
 <item>
+    <tags>'noshowhinttext' 'showhinttext'</tags>
+    <spec>'hinttext'</spec>
+    <type>&option.showhinttext.type;</type>
+    <default>&option.showhinttext.default;</default>
+    <description>
+        <p>
+            Determines if hints should show accompanying description texts
+            in addition to the shortcut.
+        </p>
+    </description>
+</item>
+
+<item>
     <tags>'hto' 'hinttimeout'</tags>
     <spec>'hinttimeout' 'hto'</spec>
     <type>&option.hinttimeout.type;</type>


### PR DESCRIPTION
`showhinttext` controls if descriptive texts are shown together with the hint's shortcut.

This came out of a series of frustrating attempts at trying to hid the extra text using custom CSS rules, which ultimately didn't work.