### PR TITLE
[wip] aliases for built-in commands

### DIFF
--- a/common/content/dactyl.js
+++ b/common/content/dactyl.js
@@ -1559,7 +1559,7 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
             "Alias a built-in command to another name",
             function (args) {
                 const command = args[0];
-                dactyl.assert(config.modules.commands.builtin._list.find(cmd => cmd.name == command), _("error.invalidCommand", command));
+                dactyl.assert(config.modules.commands.builtin._list.find(cmd => cmd.hasName(command)), _("error.invalidCommand", command));
 
                 const alias = args[1];
                 dactyl.assert(alias.match(config.modules.commands.validName), _("error.invalidCommand", alias));

--- a/common/content/dactyl.js
+++ b/common/content/dactyl.js
@@ -46,8 +46,6 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
         }));
     },
 
-    commandAliases: {},
-
     cleanup: function () {
         for (let cleanup of this.cleanups)
             cleanup.call(this);

--- a/common/content/dactyl.js
+++ b/common/content/dactyl.js
@@ -46,6 +46,8 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
         }));
     },
 
+    commandAliases: {},
+
     cleanup: function () {
         for (let cleanup of this.cleanups)
             cleanup.call(this);
@@ -1550,6 +1552,24 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
                 completer: function (context) {
                     context.ignoreCase = true;
                     completion.dialog(context);
+                }
+            });
+
+        commands.add(["alias"],
+            "Alias a built-in command to another name",
+            function (args) {
+                const command = args[0];
+                dactyl.assert(config.modules.commands.builtin._list.find(cmd => cmd.name == command), _("error.invalidCommand", command));
+
+                const alias = args[1];
+                dactyl.assert(alias.match(config.modules.commands.validName), _("error.invalidCommand", alias));
+
+                config.modules.commands.addAlias(command, alias);
+            }, {
+                argCount: "2",
+                completer: function (context) {
+                    context.ignoreCase = true;
+                    completion.ex(context);
                 }
             });
 

--- a/common/modules/commands.jsm
+++ b/common/modules/commands.jsm
@@ -629,15 +629,15 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
 
         let names = extra.parsedSpecs;
         let name = names[0];
-
+        
         if (this.name != "builtin") {
             util.assert(!names.some(name => name in commands.builtin._map),
                         _("command.cantReplace", name));
-
+        
             util.assert(replace || names.every(name => !(name in this._map)),
                         _("command.wontReplace", name));
         }
-
+        
         for (let name of names) {
             if (false)
                 // For some reason, the `this` object of the getter gets
@@ -650,7 +650,7 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
                         return this._run(name);
                     },
                 });
-
+        
             if (name in this._map && !this._map[name].isPlaceholder)
                 this.remove(name);
         }
@@ -664,6 +664,13 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
             memoize(this._map, alias, closure);
 
         return name;
+    },
+
+    addAlias: function addAlias(name, alias) {
+        let closure = () => this._list.find(cmd => cmd.hasName(name));
+        memoize(this._map, alias, closure);
+
+        return alias;
     },
 
     _add: function _add(names, description, action, extra={}, replace=false) {
@@ -925,6 +932,11 @@ var Commands = Module("commands", {
         extra.definedAt = contexts.getCaller(caller);
         return apply(group, "add", arguments);
     },
+
+    addAlias: function addAlias() {
+        return apply(this.builtin, "addAlias", arguments);
+    },
+
     addUserCommand: deprecated("group.commands.add", { get: function addUserCommand() { return this.user.bound._add } }),
     getUserCommands: deprecated("iter(group.commands)", function getUserCommands() { return iter(this.user).toArray(); }),
     removeUserCommand: deprecated("group.commands.remove", { get: function removeUserCommand() { return this.user.bound.remove; } }),

--- a/common/modules/commands.jsm
+++ b/common/modules/commands.jsm
@@ -629,15 +629,15 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
 
         let names = extra.parsedSpecs;
         let name = names[0];
-        
+
         if (this.name != "builtin") {
             util.assert(!names.some(name => name in commands.builtin._map),
                         _("command.cantReplace", name));
-        
+
             util.assert(replace || names.every(name => !(name in this._map)),
                         _("command.wontReplace", name));
         }
-        
+
         for (let name of names) {
             if (false)
                 // For some reason, the `this` object of the getter gets
@@ -650,7 +650,7 @@ var CommandHive = Class("CommandHive", Contexts.Hive, {
                         return this._run(name);
                     },
                 });
-        
+
             if (name in this._map && !this._map[name].isPlaceholder)
                 this.remove(name);
         }


### PR DESCRIPTION
closes #15

### What's missing
#### Alias' specs
(Maybe) figure out a way to use Command.parseSpecs for dealing with spec'd aliases (e.g. `alias command myal[ias]`. I kept running into weird bugs and couldn't finish going through this route.

That'd change
```
alias cnoreabbrev myabb
alias cnoreabbrev myabbrev
```

to

```
alias cnoreabbrev myabb[rev]
```

#### Documentation
That depends on whether the specs would be implemented or not.

---

I'm waiting for someone to show me the light on why Command.parseSpecs is bugged; but if alias' specs aren't desirable anyway, we can go with how it is right now.