### PR TITLE
Autocommands for tab events

### DIFF
--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -115,7 +115,7 @@ var Tabs = Module("tabs", {
         modes.reset();
         statusline.updateTabCount(true);
         this.updateSelectionHistory();
-        config.modules.autocommands.trigger("TabSelect", tabs);
+        config.modules.autocommands.trigger("TabSelect", []);
     },
 
     get allTabs() {
@@ -1150,8 +1150,10 @@ var Tabs = Module("tabs", {
     events: function initEvents() {
         let tabContainer = gBrowser.mTabContainer;
         function callback(event) {
-            tabs.timeout(function () { this.updateTabCount(); });
-            config.modules.autocommands.trigger(event, tabs);
+            tabs.timeout(function () {
+                this.updateTabCount();
+                config.modules.autocommands.trigger(event, []);
+            });
         }
         for (let event of ["TabMove", "TabOpen", "TabClose"])
             events.listen(tabContainer, event, () => callback(event), false);

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -115,6 +115,7 @@ var Tabs = Module("tabs", {
         modes.reset();
         statusline.updateTabCount(true);
         this.updateSelectionHistory();
+        config.modules.autocommands.trigger("TabSelect", tabs);
     },
 
     get allTabs() {
@@ -1148,11 +1149,12 @@ var Tabs = Module("tabs", {
     },
     events: function initEvents() {
         let tabContainer = gBrowser.mTabContainer;
-        function callback() {
+        function callback(event) {
             tabs.timeout(function () { this.updateTabCount(); });
+            config.modules.autocommands.trigger(event, tabs);
         }
         for (let event of ["TabMove", "TabOpen", "TabClose"])
-            events.listen(tabContainer, event, callback, false);
+            events.listen(tabContainer, event, () => callback(event), false);
         events.listen(tabContainer, "TabSelect", tabs.bound._onTabSelect, false);
     },
     mappings: function initMappings() {

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -110,8 +110,6 @@ var Tabs = Module("tabs", {
     },
 
     _onTabSelect: function _onTabSelect() {
-        // TODO: is all of that necessary?
-        //       I vote no. --Kris
         modes.reset();
         statusline.updateTabCount(true);
         this.updateSelectionHistory();
@@ -1149,14 +1147,16 @@ var Tabs = Module("tabs", {
     },
     events: function initEvents() {
         let tabContainer = gBrowser.mTabContainer;
-        function callback(event) {
-            tabs.timeout(function () {
-                this.updateTabCount();
-                config.modules.autocommands.trigger(event, []);
-            });
+        function callbackClosure(event) {
+            return function () {
+                tabs.timeout(function () {
+                    this.updateTabCount();
+                    config.modules.autocommands.trigger(event, []);
+                });
+            }
         }
         for (let event of ["TabMove", "TabOpen", "TabClose"])
-            events.listen(tabContainer, event, () => callback(event), false);
+            events.listen(tabContainer, event, callbackClosure(event), false);
         events.listen(tabContainer, "TabSelect", tabs.bound._onTabSelect, false);
     },
     mappings: function initMappings() {

--- a/pentadactyl/config.json
+++ b/pentadactyl/config.json
@@ -47,7 +47,11 @@
         "ShellCmdPost":     "Triggered after executing a shell command with :!cmd",
         "Enter":            "Triggered after Pale Moon starts",
         "LeavePre":         "Triggered before exiting Pale Moon, just before destroying each module",
-        "Leave":            "Triggered before exiting Pale Moon"
+        "Leave":            "Triggered before exiting Pale Moon",
+        "TabOpen":          "Triggered when a tab opens",
+        "TabClose":         "Triggered when a tab closes",
+        "TabMove":          "Triggered when a tab moves",
+        "TabSelect":        "Triggered when a tab is selected"
     },
 
     "option-defaults": {

--- a/pentadactyl/locale/en-US/autocommands.xml
+++ b/pentadactyl/locale/en-US/autocommands.xml
@@ -23,6 +23,10 @@
     <dt>Enter</dt>             <dd>Triggered after &dactyl.host; starts</dd>
     <dt>LeavePre</dt>          <dd>Triggered before exiting &dactyl.host;, just before destroying each module</dd>
     <dt>Leave</dt>             <dd>Triggered before exiting &dactyl.host;</dd>
+    <dt>TabOpen</dt>:          <dd>Triggered when a tab opens</dd>,
+    <dt>TabClose</dt>:         <dd>Triggered when a tab closes</dd>,
+    <dt>TabMove</dt>:          <dd>Triggered when a tab moves</dd>,
+    <dt>TabSelect</dt>:        <dd>Triggered when a tab is selected</dd>
 </dl>
 
 <dl tag="autocommand-args" replace="autocommand-args">


### PR DESCRIPTION
They do not bring along any relevant arguments at the moment (e.g. a `tab` argument for TabSelect) because it doesn't seem obvious on how to add them, nor there's a need for them at the moment (at least as far as my usage is concerned).

For TabSelect, it seems like the event's upbringing outlives the tab reference somehow, so it's something to look out for if implementing those arguments in the future.