### PR TITLE
Fix parse error in options.xml

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -1364,6 +1364,7 @@ var Hints = Module("hints", {
 
         options.add(["showhinttext"],
             "Enables or disables showing hints' related texts",
+            // Make sure to update the docs when you change this.
             "boolean", true);
 
         options.add(["hinttags", "ht"],

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -956,8 +956,8 @@
 <item>
     <tags>'noshowhinttext' 'showhinttext'</tags>
     <spec>'hinttext'</spec>
-    <type>&option.showhinttext.type;</type>
-    <default>&option.showhinttext.default;</default>
+    <type>boolean</type>
+    <default>true</default>
     <description>
         <p>
             Determines if hints should show accompanying description texts


### PR DESCRIPTION
The `showhinttext` option does not get included in `options.dtd`, causing `options.xml` to have a parse error preventing it from being accessible from `:help`. I could not find a more elegant way to do this (causing `showhinttext` to be included in `options.dtd`) because the code declaring the option `showhinttext` in `common/content/hints.js` seems very similar to the code declaring other options and I could not find any errors there, so I hard-coded the type and default value of `showhinttext` into `options.xml` so that `options.xml` is accessible from `:help` in Pentadactyl.