### PR TITLE
Configurable clipboard registers on X11 systems

### DIFF
--- a/common/content/dactyl.js
+++ b/common/content/dactyl.js
@@ -333,8 +333,9 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
      * apps like Thunderbird which do not provide it.
      *
      * @param {string} which Which clipboard to write to. Either
-     *     "global" or "selection". If not provided, both clipboards are
-     *     updated.
+     *     "global" or "selection". If not provided, the selection is used
+     *     unless '+' appears before '*' in the option 'defregister' or
+     *     the OS does not have a selection clipboard.
      *     @optional
      * @returns {string}
      */
@@ -345,8 +346,12 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
             let transferable = services.Transferable();
             transferable.addDataFlavor("text/unicode");
 
-            let source = clipboard[which == "global" || !clipboard.supportsSelectionClipboard() ?
-                                   "kGlobalClipboard" : "kSelectionClipboard"];
+           let source = clipboard[
+                which == "global"
+                || !clipboard.supportsSelectionClipboard()
+                || (!which && options.get("defregister").value.match(/^[^\*]*\+/)) ?
+                    "kGlobalClipboard" : "kSelectionClipboard"
+            ];
             clipboard.getData(transferable, source);
 
             let str = {}, len = {};

--- a/common/content/editor.js
+++ b/common/content/editor.js
@@ -56,8 +56,6 @@ var Editor = Module("editor", XPCOM(Ci.nsIEditActionListener, ModuleBase), {
         }, this);
     },
 
-    defaultRegister: "*+",
-
     selectionRegisters: {
         "*": "selection",
         "+": "global"
@@ -72,7 +70,7 @@ var Editor = Module("editor", XPCOM(Ci.nsIEditActionListener, ModuleBase), {
      */
     getRegister: function getRegister(name) {
         if (name == null)
-            name = editor.currentRegister || editor.defaultRegister;
+            name = editor.currentRegister || options.get("defregister").value;
 
         name = String(name)[0];
         if (name == '"')
@@ -106,7 +104,7 @@ var Editor = Module("editor", XPCOM(Ci.nsIEditActionListener, ModuleBase), {
      */
     setRegister: function setRegister(name, value, verbose) {
         if (name == null)
-            name = editor.currentRegister || editor.defaultRegister;
+            name = editor.currentRegister || options.get("defregister").value;
 
         if (isinstance(value, [Ci.nsIDOMRange, Ci.nsIDOMNode, Ci.nsISelection]))
             value = DOM.stringify(value);
@@ -1438,6 +1436,11 @@ var Editor = Module("editor", XPCOM(Ci.nsIEditActionListener, ModuleBase), {
                     context.keys = { text: identity, description: identity };
                 }
             });
+
+        options.add(["defregister", "dr"],
+            "The list of registers to use, in order of preference, for yank and put operations",
+            // Make sure to update the docs when you change this.
+            "string", "*+");
     },
     sanitizer: function initSanitizer() {
         sanitizer.addItem("registers", {

--- a/common/locale/en-US/browsing.xml
+++ b/common/locale/en-US/browsing.xml
@@ -170,6 +170,8 @@
             contents, or, on X11 systems, the currently selected
             text. All white space is stripped from the selection and
             it is opened in the same manner as <ex>:open</ex>.
+            The clipboard used on X11 systems is controlled by
+            <o>defregister</o>.
         </p>
     </description>
 </item>

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -573,6 +573,37 @@
 </item>
 
 <item>
+    <tags>'dr' 'defregister'</tags>
+    <spec>'defregister' 'dr'</spec>
+    <type>string</type>
+    <default>*+</default>
+    <description>
+        <p>
+            The list of registers (clipboards) to use, in order of
+            preference, for yank (<k>y</k>) and put
+            (<k>p</k>, <k>P</k>, and <k>gP</k>) operations on X11 systems.
+            Yank operations yank to all registers in this list and
+            put operations read from <str>*</str> or <str>+</str>,
+            whichever comes first in this list.
+
+            The value is a string consisting of any of the following
+            characters:
+
+            <dl>
+                <dt>*</dt> <dd>Tied to the PRIMARY selection value.</dd>
+                <dt>+</dt> <dd>Tied to the primary global clipboard.</dd>
+                <dt>_</dt> <dd>The null register. Never has any value.</dd>
+                <dt>"</dt> <dd>Equivalent to 0.</dd>
+                <dt>0-9</dt> <dd>
+                    These act as a kill ring. Setting any one of them pushes
+                    the values of higher numbered registers up one slot.
+                </dd>
+            </dl>
+        </p>
+    </description>
+</item>
+
+<item>
     <tags>'dls' 'dlsort' 'downloadsort'</tags>
     <spec>'downloadsort' 'dlsort' 'dls'</spec>
     <strut/>


### PR DESCRIPTION
The current behavior on X11 systems is that yank operations (`y`) write to both the `PRIMARY` (last selected text; `*` in Vim) and `CLIPBOARD` (`+` in Vim) registers, and that put operations (`p`, `P`, and `gP`) read from the `PRIMARY` register.

This patchset keeps this as the default behavior but allows the user to configure what registers are used. The JavaScript variable `editor.defaultRegister` has been made into an option `defregister`, and put operations now respect this option. The default behavior remains the same, but yank operations write to all registers in `defregister` and put operations read from `*` or `+`, whichever comes first in `defregister` (defaulting to `*`).

This should not affect the default behavior on non-X11 systems (which, to my knowledge, generally have one unified clipboard and do not have a "primary selection") because the defaults remain the same, but this is untested.