### PR TITLE
Make <summary> tags navigable using hints

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -1370,7 +1370,7 @@ var Hints = Module("hints", {
             "XPath or CSS selector strings of hintable elements for Hints mode",
             // Make sure to update the docs when you change this.
             "stringlist", ":-moz-any-link,area,button,iframe,input:not([type=hidden]):not([disabled])," +
-                          "label[for],select,textarea," +
+                          "label[for],select,textarea,summary," +
                           "[onclick],[onmouseover],[onmousedown],[onmouseup],[oncommand]," +
                           "[tabindex],[role=link],[role=button],[contenteditable=true]",
             {

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -938,7 +938,7 @@
     <spec>'hinttags' 'ht'</spec>
     <type>&option.hinttags.type;</type>
     <default>:-moz-any-link,area,button,iframe,input:not([type=hidden]),
-          label[for],select,textarea,
+          label[for],select,textarea,summary,
           [onclick],[onmouseover],[onmousedown],[onmouseup],[oncommand],
           [tabindex],[role=link],[role=button],[contenteditable=true]</default>
     <description>


### PR DESCRIPTION
Add `summary` to `hinttags` by default so that `<summary>` tags are keyboard-navigable using hints (in accordance with [Mozilla bug 1249556](https://bugzilla.mozilla.org/show_bug.cgi?id=1249556)).