### PR TITLE
fix issue #9, match got stucked on text input which is the root cause of highlight find browser hangs

### DIFF
--- a/common/modules/finder.jsm
+++ b/common/modules/finder.jsm
@@ -669,9 +669,22 @@ var RangeFind = Class("RangeFind", {
                 }
                 this.range = this.ranges[i];
 
-                let start = RangeFind.sameDocument(this.lastRange, this.range.range) && this.range.intersects(this.lastRange) ?
-                                RangeFind.endpoint(this.lastRange, !(again ^ this.backward)) :
-                                RangeFind.endpoint(this.range.range, !this.backward);
+                let is_same_doc = RangeFind.sameDocument(
+                        this.lastRange, this.range.range);
+                let is_intersected = this.range.intersects(this.lastRange);
+                let start = null;
+                if (is_same_doc && is_intersected) {
+                    start = RangeFind.endpoint(
+                                this.lastRange, !(again ^ this.backward));
+                } else {
+                    if (this.range == null || this.lastRange == null) {
+                        start = RangeFind.endpoint(
+                                this.range.range, !this.backward);
+                    } else {
+                        start = RangeFind.endpoint(
+                                this.lastRange, this.backward);
+                    }
+                }
 
                 if (this.backward && !again)
                     start = RangeFind.endpoint(this.startRange, false);


### PR DESCRIPTION
to reproduce the bug
- go to forums.gentoo.org
- search with /glsa, all works
- now to trigger the bug
  - type `glsa` in the text input field of top right corner
  - :set hlfind
  - search /glsa again, browser hangs
  - to note, without `:set hlfind`, press `n` won't go to the next match, i.e. match got stuck in type input field.